### PR TITLE
【fix】ルーティングパスの設定方法を間違えていたので修正

### DIFF
--- a/src/utils/RouteSetting.js
+++ b/src/utils/RouteSetting.js
@@ -110,7 +110,7 @@ export const RoutePath = {
     name: "ステージ選択",
   },
   gamePlay: {
-    path: Path.gamePlay(),
+    path: (id) => Path.gamePlay(id),
     name: "ゲーム画面",
   },
   gameEdit: {


### PR DESCRIPTION
修正前のルーティングだと各ページで呼び出すときの設定ができないので、各ページで呼び出せるよう修正しました。

## idが必要なページへのリンク呼び出し方法
以下は一例です
ゲームプレイ画面ステージ１に飛ぶ
```javascript
<Link to={RoutePath.gamePlay.path(1)>Stage1</Link>
```

他idが必要なページありましたらこちらのブランチで対応しますので教えて下さい。
今後idが必要なページが増えたら今回の実装のように増やしていただければ！