### PR TITLE
【feature】PC以外の端末対応

### DIFF
--- a/src/App.js
+++ b/src/App.js
@@ -2,13 +2,22 @@ import { RoutesComponent } from "components/RoutesComponent";
 import "./App.css";
 import Header from "components/Header";
 import { Footer } from "components/Footer";
+import { useDevice } from "hooks/useDevice";
 
 function App() {
+  const { isPC, isMobile } = useDevice();
+
+  if (isPC === null && isMobile === null) {
+    return;
+  }
+
   return (
     <div className="flex flex-col w-screen h-screen">
-      <header className="fixed top-0 h-14 w-full z-10">
-        <Header />
-      </header>
+      {isPC && !isMobile &&
+        <header className="fixed top-0 h-14 w-full z-10">
+          <Header />
+        </header>
+      }
       <main className="flex-1 bg-green-400">
         <RoutesComponent />
       </main>

--- a/src/components/Footer.jsx
+++ b/src/components/Footer.jsx
@@ -2,13 +2,13 @@ import React from 'react'
 
 export const Footer = () => {
   return (
-    <footer className="flex justify-between items-center p-2.5 bg-green-400">
-      <div className="flex ml-10">
-        <div className="mx-1">COPY RIGHT</div>
-        <div className="mx-1">プラバシーポリシー</div>
-        <div className="mx-1">利用規約</div>
+    <footer className="sm:relative sm:flex sm:justify-between sm:items-center p-2.5 bg-green-400">
+      <div className="text-end sm:text-start sm:flex sm:ml-10">
+        <div className="mx-1 inline-block sm:block">COPY RIGHT</div>
+        <div className="mx-1 inline-block sm:block">プラバシーポリシー</div>
+        <div className="mx-1 inline-block sm:block">利用規約</div>
       </div>
-      <p className="text-base text-black mb-2 mx-4">
+      <p className="text-base text-black mb-2 mx-4 hidden sm:block">
         ※本ゲームはPC専用となっております。
       </p>
     </footer>

--- a/src/components/RoutesComponent.jsx
+++ b/src/components/RoutesComponent.jsx
@@ -1,21 +1,31 @@
-import React from 'react'
+import { useDevice } from 'hooks/useDevice';
+import MobileHomePage from 'pages/MobileHomePage';
 import { Routes, Route } from "react-router-dom";
 import { RouteSetting } from "utils/RouteSetting";
 
 export const RoutesComponent = () => {
+  const { isPC, isMobile } = useDevice();
+
+  if (isPC === null && isMobile === null) {
+    return;
+  }
+
   return (
     <Routes>
-      {// RouteSetting.jsに設定したルーティング配列を回しています。
+      {isPC && !isMobile &&
         RouteSetting.map((route, index) => {
           return (
             <Route
               key={index}
               path={route.path}
               element={route.component}
-            />
-          )
-        })
+            />)
+        })}
+      {
+        isMobile && !isPC &&
+        <Route path="/" element={<MobileHomePage />} />
       }
+
     </Routes>
   )
 }

--- a/src/hooks/useDevice.js
+++ b/src/hooks/useDevice.js
@@ -1,0 +1,18 @@
+import { useState, useEffect } from 'react';
+
+export const useDevice = () => {
+  const [isPC, setIsPC] = useState(null);
+  const [isMobile, setIsMobile] = useState(null);
+
+  useEffect(() => {
+    const detectDevice = () => {
+      const isDesktop = !navigator.userAgent.match(/(iPhone|iPad|iPod|Android)/i);
+      setIsPC(isDesktop);
+      setIsMobile(!isDesktop);
+    };
+
+    detectDevice();
+  }, []);
+
+  return { isPC, isMobile };
+};

--- a/src/pages/MobileHomePage.jsx
+++ b/src/pages/MobileHomePage.jsx
@@ -1,0 +1,98 @@
+import { useEffect, useState } from "react";
+import { Bodies, Composite, Engine, Render, Runner } from "matter-js";
+
+const MobileHomePage = () => {
+  const [SCREEN_WIDTH, setScreenWidth] = useState(0);
+  const [SCREEN_HEIGHT, setScreenHeight] = useState(0);
+  const [engine, setEngine] = useState(null);
+  const [render, setRender] = useState(null);
+
+  useEffect(() => {
+    setScreenWidth(document.body.clientWidth);
+    setScreenHeight(document.body.clientHeight);
+  }, []);
+
+  useEffect(() => {
+    if (SCREEN_WIDTH === 0 || SCREEN_HEIGHT === 0) return;
+    matterInitialize();
+
+    return () => {
+      if (render) Render.stop(render);
+      if (engine) Runner.stop(engine);
+    };
+  }, [SCREEN_WIDTH, SCREEN_HEIGHT]);
+
+  // MatterEngineがゲーム専用に作ってしまっておりこちらへの実用が難しかったため、matter.jsでやっています。
+  const matterInitialize = () => {
+    const parent = document.getElementById("Back-Object");
+    const mEngine = Engine.create();
+    const mRender = Render.create({
+      element: parent,
+      engine: mEngine,
+      options: {
+        width: SCREEN_WIDTH,
+        height: SCREEN_HEIGHT,
+        wireframes: false,
+        background: "transparent",
+      },
+    });
+    setEngine(mEngine);
+    setRender(mRender);
+    Render.run(mRender);
+
+    Composite.add(mEngine.world, [createGround(), spawnObjects()]);
+    Runner.run(Runner.create(), mEngine);
+  };
+
+  const createGround = () => {
+    // 床部分。透過して見えなくしている。
+    const GROUND_HEIGHT = 30;
+    const ground = Bodies.rectangle(SCREEN_WIDTH / 2, SCREEN_HEIGHT - GROUND_HEIGHT, SCREEN_WIDTH, GROUND_HEIGHT, { isStatic: true, render: { fillStyle: "transparent" } });
+    return ground
+  }
+
+  const spawnObjects = () => {
+    const spawnComposite = Composite.create();
+    // ランダムで物理オブジェクトを生成
+    const SPAWN_HEIGHT = 500;
+    const SPAWN_HEIGHT_RANGE = 20;
+    const SPAWN_ANGLE = 360;
+    const SPAWN_SIZE = 50;
+    const SPAWN_TYPE = 3;
+    for (let i = 0; i < 30; i++) {
+      // ごちゃっと感を出すためにランダムで生成
+      const objectType = Math.floor(Math.random() * SPAWN_TYPE);
+      const posX = Math.random() * SCREEN_WIDTH;
+      const posY = Math.random() * (SPAWN_HEIGHT + SPAWN_HEIGHT_RANGE) - SPAWN_HEIGHT;
+      const rotate = Math.random() * SPAWN_ANGLE;
+      let spawnObject;
+      switch (objectType) {
+        case 1: // 三角形
+          spawnObject = Bodies.polygon(posX, posY, 3, SPAWN_SIZE, { rotate });
+          break
+        case 2: // 方形
+          spawnObject = Bodies.rectangle(posX, posY, SPAWN_SIZE, SPAWN_SIZE, { rotate });
+          break;
+        default: // 円
+          // 大きくなりすぎてバランス悪くなるので他のサイズから半分にしています
+          spawnObject = Bodies.circle(posX, posY, SPAWN_SIZE / 2, { rotate });
+          break;
+      }
+      Composite.add(spawnComposite, spawnObject);
+    }
+    return spawnComposite;
+  }
+
+  return (
+    <div className="w-full h-full relative flex justify-center items-center pb-32 font-[DotGothic16]">
+      <div id="Back-Object" className="w-screen h-screen absolute top-0 left-0 overflow-hidden"></div>
+      <div className="z-10">
+        <div className="pt-5 pb-5 pl-15 pr-15 rounded-3xl border-4 border-black text-center text-shadow-black ">
+          <h1 className="text-5xl md:text-8xl my-3 mx-10 text-yellow-300">Pythagora<br />maker</h1>
+        </div>
+        <p>このゲームはPC専用です。PCで遊んでね！</p>
+      </div>
+    </div>
+  );
+};
+export default MobileHomePage;


### PR DESCRIPTION
PC以外の端末でアクセスしたときに専用のホーム画面を表示するようにしました。
[![Image from Gyazo](https://i.gyazo.com/504c59138253e88f0eee9f32740ad93e.gif)](https://gyazo.com/504c59138253e88f0eee9f32740ad93e)
上記Gifなのでカクついてます。
[動画版はこちら](https://i.gyazo.com/504c59138253e88f0eee9f32740ad93e.mp4)

黒い丸はカーソルです。

### 内容
ヘッダーを完全排除
フッターの位置調整
スポーンオブジェクトの数をちょっと減らしました
ルーティングで他のURLに遷移できないようにしています

現在404ページがないので、URL直打ちで別ページへ飛ぶとグリーンな世界が広がるのみの状態です。
404ページは今回の作業から外しています。
通常のホームページコンポーネントと中身が近いですが、リファクタリングは後回しにする方向を考え内容のコンポーネント化はしていません。

実機での動作確認はできていません