### PR TITLE
【feature】ゲーム開始時にカウントダウン

### DIFF
--- a/src/pages/game/GamePlay.jsx
+++ b/src/pages/game/GamePlay.jsx
@@ -137,9 +137,14 @@ export const GamePlay = () => {
             <div className="w-full flex">
               <div className="w-1/4 grid grid-flow-col items-center text-start">
                 <button
-                  className="hover:bg-blue-200 bg-blue-400 hover:text-slate-500 text-slate-950 transition-all py-2"
+                  className={`hover:text-slate-500 text-slate-950 ${
+                    countDown > 0
+                      ? "hover:bg-gray-900 bg-gray-600"
+                      : "hover:bg-red-200 bg-blue-400"
+                  } transition-all py-2 px-4 my-2`}
                   onClick={handlePlacementReset}
                   aria-label="ユーザーは位置オブジェクトのリセット"
+                  disabled={countDown > 0}
                 >
                   Reset
                 </button>
@@ -148,9 +153,14 @@ export const GamePlay = () => {
               <div className="w-3/4 flex flex-col">
                 <div className="flex justify-between items-center mx-5">
                   <button
-                    className="hover:bg-blue-200 bg-blue-400 hover:text-slate-500 text-slate-950 transition-all py-2 px-4 my-2"
+                    className={`hover:text-slate-500 text-slate-950 ${
+                      countDown > 0
+                        ? "hover:bg-gray-900 bg-gray-600"
+                        : "hover:bg-red-200 bg-blue-400"
+                    } transition-all py-2 px-4 my-2`}
                     onClick={handleBallReset}
                     aria-label="ボールの位置をリセット"
+                    disabled={countDown > 0}
                   >
                     BallReset
                   </button>


### PR DESCRIPTION
## 概要
- ゲーム開始時にカウントダウンを行います
- カウントダウンが終わるまで各種ボタンは押せません

## リミテーション
カウントダウン中、ゲームスタートボタンは押せませんが`オブジェクトの配置はできる`ようになっています。
3秒の猶予を使って配置済ませるというのもまあゲーム要素かなという前向きな思いと、また、オブジェクト配置機能はボタン制御ではないためGameコンポーネントに直接作用させる必要があるという手間の問題で、ひとまずこの仕様にしています。

動画（＊カウントダウン中、ゲーム開始ボタンだけ無効化していますがその後他のボタンも修正しています）
https://www.youtube.com/watch?v=pfBqefrPLU8
↑URL間違ってました。修正しています