### PR TITLE
【add】User'sタブで公開、非公開それぞれのステージの表示設定を実装 #71

### DIFF
--- a/src/services/supabaseStages.js
+++ b/src/services/supabaseStages.js
@@ -1,4 +1,5 @@
 import supabase from "./supabaseClient";
+import { State } from "utils/GameSetting";
 
 const Response = {
   success: "success",
@@ -36,7 +37,7 @@ export const getUsersStagesRange = async ({ start, end }) => {
     if (profilesError) throw profilesError;
     const profileIds = userProfiles.map(profile => profile.id);
 
-    const { data: stages, error: stagesError } = await supabase.from('stages').select('id, profile_id, title, image').in('profile_id', profileIds).range(start, end);
+    const { data: stages, error: stagesError } = await supabase.from('stages').select('id, profile_id, title, image').in('profile_id', profileIds).eq('state', State.release).range(start, end);
     if (stagesError) throw stagesError;
 
     // ステージデータにユーザー名を合体！


### PR DESCRIPTION
User's タブ内で表示しているユーザー作成ステージを、stateが「公開」のもののみを表示させるように実装しました！

※動画をリサイズしたら文字がガビガビになっちゃいましたすみません…！🙇‍♂️
※commitで「state」を「status」と打ち間違えています…🥹

https://github.com/raito2180/pythagora_maker/assets/138564916/cd5bc7f9-2615-4728-bc1d-e02570992114

