### PR TITLE
ページの見た目を調整しました

### DIFF
--- a/src/pages/game/GameProduction.jsx
+++ b/src/pages/game/GameProduction.jsx
@@ -243,11 +243,6 @@ import notSet from "../../assets/imgs/notSet/NotSet.png";
               </button>
             </div>
           </div>
-          <div className="flex items-center justify-center">
-            <h1 className="font-bold text-2xl px-8">
-              <img src={notSet} alt="NotSet" style={{ width: "150px", height: "100px" }} />     {/* TODO:画像処理*/}
-            </h1>
-          </div>
         </div>
       </li>
       ))}


### PR DESCRIPTION
- [x] ステージセレクト画面のCreate Editと、ステージデータの色を合わせました
- [x]  ステージセレクト画面のタブと同じ動作をステージデータにも導入しました。

NotSet画像があった個所にプロフィールのアイコン入れた方がモチベ上がりますかね(例えば自分の好きなキャラクターなど設定していたらステージ制作画面で目の保養になる)、画像取り除きましたが意見頂けると幸いです