### PR TITLE
【fix】ボール転がし中はオブジェクトの選択を不可に修正

### DIFF
--- a/src/components/Game.jsx
+++ b/src/components/Game.jsx
@@ -17,6 +17,7 @@ export const Game = memo(
     setIsGameCompleted,
     stageId,
   }) => {
+    const [isPlaying, setIsPlaying] = useState(false);
     const [isMousePosXLeft, setIsMousePosXLeft] = useState(true);
     const gameDataRef = useRef();
     const matterEngineRef = useRef();
@@ -213,6 +214,7 @@ export const Game = memo(
     };
 
     const resetBall = () => {
+      setIsPlaying(false);
       // 親コンポーネントのボールリセットボタンの処理
       matterEngineRef.current.clearComposite(ballCompositeRef.current);
       const ball = createObjects(gameDataRef.current.Ball, ObjectType.Ball);
@@ -223,6 +225,7 @@ export const Game = memo(
     };
 
     const play = () => {
+      setIsPlaying(true);
       // 親コンポーネントのプレイボタンの処理
       ballCompositeRef.current.bodies.forEach((ball) => {
         ball.getParent().setStatic(false);
@@ -244,10 +247,13 @@ export const Game = memo(
     };
 
     return (
-      <div
-        id="Game"
-        className={`w-[1200px] m-auto bg-white overflow-hidden ${stageNum}`}
-      ></div>
+      <>
+        <div
+          id="Game"
+          className={`w-[1200px] m-auto bg-white overflow-hidden ${stageNum}`}
+        ></div>
+        {isPlaying && <div className="fixed top-28 left-0 w-full h-full z-10"></div>}
+      </>
     );
   }
 );


### PR DESCRIPTION
## 挙動
[挙動](https://i.gyazo.com/668f524a6907bd1c1b28b689895e3279.mp4)

ゲームプレイ中はオブジェクトを移動できないようにしました。

## 補足
現在物理オブジェクト（物理演算により移動するオブジェクト）をクリックしての移動は、私の実装ではなくmatter.jsにもともとある処理で移動しています。
静止オブジェクトについては移動の制約ができるのですが、物理オブジェクトはmatter.js側で移動制約の実装がないようで、実装するとなると工夫が必要だということが判明しました。
マウスとオブジェクトにコリジョンフィルター（物理判定のフィルタリング）を付与しての移動制約も試してみましたが、上手くいきませんでした。
応急処置として「再生中は見えないレイヤーを上にかぶせ擬似的に押せなくする」対処をしています。
オブジェクト描画域（canvasタグ）内のクリック制御も考えたのですが実装が楽な方とりました。
リファクタリングあるいはもう少しmatter.jsへの理解が深まったら別途対応できたらと考えてはいます（できるかは不明）