### PR TITLE
【fix】ユーザー配置・ステージ配置の動くオブジェクトの扱いについて修正しました

### DIFF
--- a/src/components/GameEditProcess.jsx
+++ b/src/components/GameEditProcess.jsx
@@ -213,11 +213,11 @@ export const GameEditProcess = ({
   const returnUserProperty = (object) => {
     const position = changePosition(object.position);
     position.x = UserPlacementCenterX
-    const isStatic = object.isStatic;
+    const label = object.label;
+    const isStatic = object.label === "userMove" ? false : object.isStatic;
     const objectId = object.id;
     const bodiesType = object.bodiesType;
     const objectType = object.objectType;
-    const label = 'userStatic';
 
     // 共通プロパティ
     let property = {

--- a/src/components/GameEditSettings.jsx
+++ b/src/components/GameEditSettings.jsx
@@ -35,8 +35,8 @@ export const GameEditSettings = ({
   const radiusRef = useRef();
   const sidesRef = useRef();
   const angleRef = useRef();
-  const [ objectType, setObjectType ] = useState();
-  const [ isOnUser, setIsOnUser ] = useState(false);
+  const [objectType, setObjectType] = useState();
+  const [isOnUser, setIsOnUser] = useState(false);
   const staticRef = useRef();
   const reGenerateObjectRef = useRef();
   const DEFAULT_X = 0;
@@ -51,12 +51,12 @@ export const GameEditSettings = ({
   const WIDTH_ZERO = 0;
   const HEIGHT_ZERO = 0;
   const SELECT_OBJECT_OUTLINE_WIDTH = 5;
-  const EDIT_SCALE = 2/3;
-  const HALF_SCALE = 1/2;
+  const EDIT_SCALE = 2 / 3;
+  const HALF_SCALE = 1 / 2;
 
   useEffect(() => {
     if (!engine) return;
-    
+
     setXY();
     setSizeSettings();
     setType();
@@ -152,9 +152,10 @@ export const GameEditSettings = ({
     }
 
     // ラベルに応じて固定設定を設定
-    staticRef.current.value = selectObjectRef.current.getParent().object.label === 'stageMove' ? 'dynamic' : 'static';
+    const label = selectObjectRef.current.getParent().object.label
+    staticRef.current.value = (label === 'stageMove' || label === "userMove") ? 'dynamic' : 'static';
   }
-    
+
 
   // ボディタイプに応じてオブジェクトを再生成
   const reGenerateObject = () => {
@@ -167,7 +168,9 @@ export const GameEditSettings = ({
     const object = selectObjectRef.current.getParent().object;
     let label = null;
     // ステージの場合、移動できるかどうかでラベルを変更
-    if (objectType === 'Stage') {
+    if (isOnUser) {
+      label = staticRef.current.value === 'static' ? 'userStatic' : 'userMove';
+    } else if (objectType === 'Stage') {
       label = staticRef.current.value === 'static' ? 'stage' : 'stageMove';
     } else {
       label = object.label;
@@ -420,7 +423,6 @@ export const GameEditSettings = ({
       </div>
       <div className="w-full h-1/2 flex">
         <div className="w-2/6 h-full"></div>
-        {(objectType === 'Stage' && !isOnUser) && (
         <div className="w-1/6 h-full flex flex-col items-center">
           <label>固定するか</label>
           <select ref={staticRef} className="form-select bg-gray-50 border border-gray-300 text-gray-900 text-sm rounded-lg focus:ring-blue-500 focus:border-blue-500 block p-2.5 dark:bg-gray-700 dark:border-gray-600 dark:placeholder-gray-400 dark:text-white dark:focus:ring-blue-500 dark:focus:border-blue-500 text-center">
@@ -428,8 +430,7 @@ export const GameEditSettings = ({
             <option value="dynamic">固定しない</option>
           </select>
         </div>
-        )}
-        {(objectType === 'Ball' || objectType === 'Switch' || isOnUser) && (
+        {(objectType === 'Ball' || objectType === 'Switch') && (
           <div className="w-1/6 h-full"></div>
         )}
         <div className="w-1/6 h-full flex items-center justify-center">

--- a/src/components/StageEditor.jsx
+++ b/src/components/StageEditor.jsx
@@ -37,8 +37,8 @@ export const StageEditor = ({
   const isMouseDownRef = useRef(false);
   const isBeforeOnStageRef = useRef(false);
   const mouseClickPositionRef = useRef({ x: 0, y: 0 });
-  const EDIT_SCALE = 2/3;
-  const HALF_SCALE = 1/2;
+  const EDIT_SCALE = 2 / 3;
+  const HALF_SCALE = 1 / 2;
   const MULTIPLY_SCALE = 2;
   const SELECT_OBJECT_OUTLINE_WIDTH = 5;
 
@@ -107,6 +107,8 @@ export const StageEditor = ({
     if (gameData.content && gameData.content.UserPlacement) {
       const userObjects = createObjects(gameData.content.UserPlacement, ObjectType.Stage);
       userObjects.forEach((userObject) => {
+        // 動くと面倒なので静的オブジェクトに設定
+        userObject.setStatic(true);
         changeScale(userObject);
         userObject.multiplyScale(HALF_SCALE);
         const position = userObject.getPosition();
@@ -141,14 +143,14 @@ export const StageEditor = ({
   const handleClick = (e) => {
     isMouseDownRef.current = true;
     const target = e.source.body;
- 
+
     if (!setSelectObject(target)) return;
 
     // クリックしたオブジェクトがユーザーが配置できるオブジェクトなら選択する
     const diff_x = e.mouse.position.x - target.position.x;
     const diff_y = e.mouse.position.y - target.position.y;
     mouseClickPositionRef.current = { x: diff_x, y: diff_y };
-    
+
     // パレット上のオブジェクトを選択したら複製する
     if (isOnPalette(target.position.x)) cloneObject(target);
 
@@ -208,7 +210,7 @@ export const StageEditor = ({
     }
 
     parent.setPosition({ x, y });
-    
+
     setSelectObjectXY(x, y);
 
     // ドラッグ前後でステージから出入りした場合はスケールを変更
@@ -247,7 +249,7 @@ export const StageEditor = ({
     object.multiplyScale(EDIT_SCALE);
   }
 
-  
+
   // オブジェクトを複製
   const cloneObject = (object) => {
     const label = object.label;

--- a/src/pages/game/GamePlay.jsx
+++ b/src/pages/game/GamePlay.jsx
@@ -10,7 +10,7 @@ export const GamePlay = () => {
   const [loading, setLoading] = useState(true);
   const [isGameCompleted, setIsGameCompleted] = useState(false);
   const onClickPlay = useRef();
-  const onClickBallReset = useRef();
+  const onClickStageReset = useRef();
   const onClickPlacementReset = useRef();
   const [gameData, setGameData] = useState(null);
   const [countTime, setCountTime] = useState(0);
@@ -118,11 +118,11 @@ export const GamePlay = () => {
     onClickPlacementReset.current();
   }, [onClickPlacementReset]);
 
-  // ボールリセットボタンの処理
-  const handleBallReset = useCallback(() => {
-    if (!onClickBallReset.current) return;
-    onClickBallReset.current();
-  }, [onClickBallReset]);
+  // ステージリセットボタンの処理
+  const handleStageReset = useCallback(() => {
+    if (!onClickStageReset.current) return;
+    onClickStageReset.current();
+  }, [onClickStageReset]);
 
   // 再生ボタンの処理
   const handleClickPlay = useCallback(() => {
@@ -141,8 +141,8 @@ export const GamePlay = () => {
               <div className="w-1/4 grid grid-flow-col items-center text-start">
                 <button
                   className={`hover:text-slate-500 text-slate-950 ${countDown > 0
-                      ? "hover:bg-gray-900 bg-gray-600"
-                      : "hover:bg-red-200 bg-blue-400"
+                    ? "hover:bg-gray-900 bg-gray-600"
+                    : "hover:bg-red-200 bg-blue-400"
                     } transition-all py-2 px-4 my-2`}
                   onClick={handlePlacementReset}
                   aria-label="ユーザーは位置オブジェクトのリセット"
@@ -156,21 +156,21 @@ export const GamePlay = () => {
                 <div className="flex justify-between items-center mx-5">
                   <button
                     className={`hover:text-slate-500 text-slate-950 ${countDown > 0
-                        ? "hover:bg-gray-900 bg-gray-600"
-                        : "hover:bg-red-200 bg-blue-400"
+                      ? "hover:bg-gray-900 bg-gray-600"
+                      : "hover:bg-red-200 bg-blue-400"
                       } transition-all py-2 px-4 my-2`}
-                    onClick={handleBallReset}
-                    aria-label="ボールの位置をリセット"
+                    onClick={handleStageReset}
+                    aria-label="ステージをリセット"
                     disabled={countDown > 0}
                   >
-                    BallReset
+                    StageReset
                   </button>
                   <h3 className="text-2xl">{gameData.title}</h3>
                   <p>{transformTime(countTime)}</p>
                   <button
                     className={`hover:text-slate-500 text-slate-950 ${countDown > 0
-                        ? "hover:bg-gray-900 bg-gray-600"
-                        : "hover:bg-red-200 bg-red-400"
+                      ? "hover:bg-gray-900 bg-gray-600"
+                      : "hover:bg-red-200 bg-red-400"
                       } transition-all py-2 px-4 my-2`}
                     onClick={handleClickPlay}
                     aria-label="再生"
@@ -185,7 +185,7 @@ export const GamePlay = () => {
               stageData={gameData.content}
               setOnClickPlay={onClickPlay}
               setOnClickPlacementReset={onClickPlacementReset}
-              setOnClickBallReset={onClickBallReset}
+              onClickStageReset={onClickStageReset}
               setIsGameCompleted={setIsGameCompleted}
               stageId={id}
             />

--- a/src/pages/game/TestPlay.jsx
+++ b/src/pages/game/TestPlay.jsx
@@ -13,7 +13,7 @@ export const TestPlay = () => {
   const [isUserPlacement, setIsUserPlacement] = useState(false);
   const [isGameCompleted, setIsGameCompleted] = useState(false);
   const onClickPlay = useRef();
-  const onClickBallReset = useRef();
+  const onClickStageReset = useRef();
   const onClickPlacementReset = useRef();
   const [gameData, setGameData] = useState(null);
   const [countTime, setCountTime] = useState(0);
@@ -135,11 +135,11 @@ export const TestPlay = () => {
     onClickPlacementReset.current();
   }, [onClickPlacementReset]);
 
-  // ボールリセットボタンの処理
-  const handleBallReset = useCallback(() => {
-    if (!onClickBallReset.current) return;
-    onClickBallReset.current();
-  }, [onClickBallReset]);
+  // ステージリセットボタンの処理
+  const handleStageReset = useCallback(() => {
+    if (!onClickStageReset.current) return;
+    onClickStageReset.current();
+  }, [onClickStageReset]);
 
   // 再生ボタンの処理
   const handleClickPlay = useCallback(() => {
@@ -206,11 +206,11 @@ export const TestPlay = () => {
                         ? "hover:bg-gray-900 bg-gray-600"
                         : "hover:bg-blue-200 bg-blue-400"
                         } transition-all py-2 px-4 my-2`}
-                      onClick={handleBallReset}
-                      aria-label="ボールの位置をリセット"
+                      onClick={handleStageReset}
+                      aria-label="ステージをリセット"
                       disabled={countDown > 0}
                     >
-                      BallReset
+                      StageReset
                     </button>
                     <button
                       className={`hover:text-slate-500 text-slate-950 ${countDown > 0
@@ -255,7 +255,7 @@ export const TestPlay = () => {
               stageData={gameData.content}
               setOnClickPlay={onClickPlay}
               setOnClickPlacementReset={onClickPlacementReset}
-              setOnClickBallReset={onClickBallReset}
+              onClickStageReset={onClickStageReset}
               setIsGameCompleted={setIsGameCompleted}
               stageId={id}
             />

--- a/src/utils/GameSetting.js
+++ b/src/utils/GameSetting.js
@@ -143,7 +143,7 @@ export const ObjectType = {
 // オブジェクトの配色
 export const ColorSetting = {
   StageStatic: "gray",
-  StageMove: "yellow",
+  StageMove: "orange",
   Switch: "red",
   UserStatic: "blue",
   UserMove: "green",

--- a/src/utils/matterjs/objects/MatterObject.js
+++ b/src/utils/matterjs/objects/MatterObject.js
@@ -122,7 +122,7 @@ export class MatterObject {
     }
     // レンダーオプションがなければ色設定を追加して返却
     if (option) {
-      return { ...option, render: this.getColor(option.isStatic) };
+      return { ...option, render: this.getColor(option.label === "stage" || option.label === "userStatic") };
     }
     let isStatic = option && option.isStatic !== undefined;
     // オプションがなければ色設定のみ返却
@@ -144,7 +144,7 @@ export class MatterObject {
       case ObjectType.Switch:
         colorSet = { fillStyle: ColorSetting.Switch };
         break;
-      case ObjectType.User:
+      case ObjectType.User || ObjectType.UserPlacement:
         if (isStatic) colorSet = { fillStyle: ColorSetting.UserStatic };
         else colorSet = { fillStyle: ColorSetting.UserMove };
         break;


### PR DESCRIPTION
# 概要
ユーザーが配置するオブジェクトとステージオブジェクトに物理挙動の実装をしました。
ステージオブジェクトで物理挙動するものについては「再生ボタンを押したら」挙動するようにしています。
こうしないとmatter.js内部の実装により自由に動かせてしまうためです。

# 挙動
[動画](https://i.gyazo.com/018f22a9d9262be4e21e7d41e9b0aafc.mp4)