### PR TITLE
【feature】編集画面にてテーマ設定

### DIFF
--- a/src/components/Game.jsx
+++ b/src/components/Game.jsx
@@ -271,8 +271,6 @@ export const Game = memo(
       );
     };
 
-    console.log(stageNum);
-
     return (
       <>
         <div

--- a/src/components/Game.jsx
+++ b/src/components/Game.jsx
@@ -19,6 +19,7 @@ export const Game = memo(
   }) => {
     const [isPlaying, setIsPlaying] = useState(false);
     const [isMousePosXLeft, setIsMousePosXLeft] = useState(true);
+    const [stageNum, setStageNum] = useState(`game-stage-${stageId}`);
     const gameDataRef = useRef();
     const matterEngineRef = useRef();
     const userPlacementCompositeRef = useRef();
@@ -45,9 +46,6 @@ export const Game = memo(
         console.error(error);
       }
     }, []);
-
-    // CSSクラス名にstageIdを含める
-    const stageNum = `game-stage-${stageId}`;
 
     useEffect(() => {
       try {
@@ -115,6 +113,8 @@ export const Game = memo(
       if (stageData.Ball) {
         createCompositeObject(ballCompositeRef, stageData.Ball, ObjectType.Ball);
         stageObjects.push(ballCompositeRef.current);
+        // TODO : ボールのテーマをステージのテーマにしている
+        setStageNum(`game-stage-${stageData.Ball.theme}`);
       }
       setOnClickPlay.current = play;
       onClickStageReset.current = resetStage;
@@ -270,6 +270,8 @@ export const Game = memo(
         userPlacementObj
       );
     };
+
+    console.log(stageNum);
 
     return (
       <>

--- a/src/components/GameEditProcess.jsx
+++ b/src/components/GameEditProcess.jsx
@@ -133,6 +133,7 @@ export const GameEditProcess = ({
     const objectId = object.id;
     const bodiesType = object.bodiesType;
     const objectType = object.objectType;
+    const theme = object.theme;
 
     // ラベルは小文字にしないといけないので変換
     let label = null;
@@ -146,7 +147,6 @@ export const GameEditProcess = ({
 
     if (objectType === 'Stage' && object.label !== 'stageMove') label = 'stage';
 
-
     // 共通プロパティ
     let property = {
       // 丸め誤差の修正
@@ -157,9 +157,11 @@ export const GameEditProcess = ({
         isStatic: isStatic,
         objectId: objectId,
         bodiesType: bodiesType,
-        objectType: objectType
+        objectType: objectType,
+        theme: theme
       },
-      bodiesType: bodiesType
+      bodiesType: bodiesType,
+      theme: theme
     };
 
     // 円の場合
@@ -218,6 +220,7 @@ export const GameEditProcess = ({
     const objectId = object.id;
     const bodiesType = object.bodiesType;
     const objectType = object.objectType;
+    const theme = object.theme;
 
     // 共通プロパティ
     let property = {
@@ -228,9 +231,11 @@ export const GameEditProcess = ({
         isStatic: isStatic,
         objectId: objectId,
         bodiesType: bodiesType,
-        objectType: objectType
+        objectType: objectType,
+        theme: theme
       },
-      bodiesType: bodiesType
+      bodiesType: bodiesType,
+      theme: theme
     };
 
     // 円の場合

--- a/src/components/GameEditSettings.jsx
+++ b/src/components/GameEditSettings.jsx
@@ -37,7 +37,8 @@ export const GameEditSettings = ({
   const angleRef = useRef();
   const [objectType, setObjectType] = useState();
   const [isOnUser, setIsOnUser] = useState(false);
-  const staticRef = useRef();
+  const staticRef = useRef("static");
+  const themeRef = useRef(1);
   const reGenerateObjectRef = useRef();
   const DEFAULT_X = 0;
   const DEFAULT_Y = 0;
@@ -177,6 +178,7 @@ export const GameEditSettings = ({
     }
     const bodiesType = object.bodiesType;
     const objectId = object.objectId;
+    const theme = themeRef.current.value;
 
     let property = {
       x: x,
@@ -186,9 +188,10 @@ export const GameEditSettings = ({
         isStatic: true,
         label: label,
         bodiesType: bodiesType,
-        objectType: objectType
+        objectType: objectType,
+        theme: theme
       },
-      bodiesType: bodiesType
+      bodiesType: bodiesType,
     };
 
     // 長方形の場合
@@ -421,8 +424,7 @@ export const GameEditSettings = ({
           </select>
         </div>
       </div>
-      <div className="w-full h-1/2 flex">
-        <div className="w-2/6 h-full"></div>
+      <div className="w-full h-1/2 flex items-center justify-end">
         <div className="w-1/6 h-full flex flex-col items-center">
           <label>固定するか</label>
           <select ref={staticRef} className="form-select bg-gray-50 border border-gray-300 text-gray-900 text-sm rounded-lg focus:ring-blue-500 focus:border-blue-500 block p-2.5 dark:bg-gray-700 dark:border-gray-600 dark:placeholder-gray-400 dark:text-white dark:focus:ring-blue-500 dark:focus:border-blue-500 text-center">
@@ -430,9 +432,20 @@ export const GameEditSettings = ({
             <option value="dynamic">固定しない</option>
           </select>
         </div>
-        {(objectType === 'Ball' || objectType === 'Switch') && (
-          <div className="w-1/6 h-full"></div>
-        )}
+        <div className="w-1/6 h-full flex flex-col items-center">
+          <label>テーマ</label>
+          <select ref={themeRef} className="form-select bg-gray-50 border border-gray-300 text-gray-900 text-sm rounded-lg focus:ring-blue-500 focus:border-blue-500 block p-2.5 dark:bg-gray-700 dark:border-gray-600 dark:placeholder-gray-400 dark:text-white dark:focus:ring-blue-500 dark:focus:border-blue-500 text-center">
+            <option value="1">RUNTEQ</option>
+            <option value="2">Cosmos</option>
+            <option value="3">Farm</option>
+            <option value="4">SweetsLand</option>
+            <option value="5">Beach</option>
+            <option value="6">Dragon</option>
+            <option value="7">Osaka</option>
+            <option value="8">Cyberpunk</option>
+          </select>
+          <small className='text-xs'>※反映はプレイ画面にて</small>
+        </div>
         <div className="w-1/6 h-full flex items-center justify-center">
           <button
             type="button"

--- a/src/components/StageEditor.jsx
+++ b/src/components/StageEditor.jsx
@@ -82,6 +82,7 @@ export const StageEditor = ({
     if (gameData.content && gameData.content.Ball) {
       const ballObjects = createObjects(gameData.content.Ball, ObjectType.Ball);
       ballObjects.forEach((object) => {
+        disableTexture(object);
         changeScale(object);
         Composite.add(engine.world, object.getObject());
       });
@@ -98,6 +99,7 @@ export const StageEditor = ({
     if (gameData.content && gameData.content.Stage) {
       const stageObjects = createObjects(gameData.content.Stage, ObjectType.Stage);
       stageObjects.forEach((object) => {
+        disableTexture(object);
         changeScale(object);
         Composite.add(engine.world, object.getObject());
       });
@@ -279,6 +281,11 @@ export const StageEditor = ({
   const isOnPalette = (x) => {
     return x > StageEndX;
   }
+
+  // 編集画面で画像が貼られているとサイズ感が分かりづらいので画像を表示しない
+  const disableTexture = (object) => {
+    object.getObject().render.sprite = null;
+  };
 
   return (
     <div id="stageEditor"></div>

--- a/src/pages/game/GameEdit.jsx
+++ b/src/pages/game/GameEdit.jsx
@@ -14,11 +14,11 @@ import { getStageById } from "services/supabaseStages";
 
 export const GameEdit = () => {
   const { id } = useParams();
-  const [ engine, setEngine ] = useState(null);
-  const [ gameData, setGameData ] = useState(null);
-  const [ selectObjectX, setSelectObjectX ] = useState(null);
-  const [ selectObjectY, setSelectObjectY ] = useState(null);
-  const [ selectObjectType, setSelectObjectType ] = useState(null);
+  const [engine, setEngine] = useState(null);
+  const [gameData, setGameData] = useState(null);
+  const [selectObjectX, setSelectObjectX] = useState(null);
+  const [selectObjectY, setSelectObjectY] = useState(null);
+  const [selectObjectType, setSelectObjectType] = useState(null);
   const selectObjectRef = useRef(null);
 
   useEffect(() => {
@@ -55,7 +55,7 @@ export const GameEdit = () => {
   return (
     <>
       {(gameData) && (
-        <div className="w-[1280px] h-[720px] m-auto font-[DotGothic16]">
+        <div className="w-[1280px] h-[740px] m-auto font-[DotGothic16]">
           <div className="w-full m-auto mt-14 flex items-center">
             <h1 className="text-5xl">Edit</h1>
             <Link to={RoutePath.gameProduction.path} className="ml-auto text-2xl">一覧へ戻る</Link>
@@ -81,7 +81,7 @@ export const GameEdit = () => {
               setSelectObjectY={setSelectObjectY}
               setSelectObjectType={setSelectObjectType}
               stageId={id}
-              />
+            />
             <div className="w-full grow m-auto mt-4 flex">
               <div className="w-4/6 h-full mr-4 flex flex-col bg-white">
                 <h2 className="text-1xl border-2 border-black">
@@ -109,7 +109,7 @@ export const GameEdit = () => {
                   setSelectObjectY={setSelectObjectY}
                   selectObjectType={selectObjectType}
                   setSelectObjectType={setSelectObjectType}
-                  />
+                />
               </div>
               <div className="w-2/6 h-full flex flex-col bg-white">
                 <h2 className="text-1xl border-2 border-black">処理</h2>
@@ -117,7 +117,7 @@ export const GameEdit = () => {
                   engine={engine}
                   stageId={id}
                   gameData={gameData}
-                  />
+                />
               </div>
             </div>
           </div>


### PR DESCRIPTION
# 概要
編集画面にてテーマの設定をできるようにしました。

## 挙動
[挙動](https://i.gyazo.com/da0f5014a50c8a0b7814bdea7eca9447.mp4)

## 仕様
テクスチャのサイズと衝突判定のサイズが異なるため、編集画面では操作のしやすさからテクスチャを削除しています。
テストプレイ・ゲームプレイで反映させる仕様です。
背景画像はボールに割り当てられたテーマを利用するようにしています