### PR TITLE
【fix】テストプレイで操作できない不具合

### DIFF
--- a/src/components/GameEditProcess.jsx
+++ b/src/components/GameEditProcess.jsx
@@ -61,7 +61,6 @@ export const GameEditProcess = ({
 
     // ユーザーオブジェクトのプロパティを取得
     const userPlacements = getUserPlacements(engine.world.bodies);
-    console.log(userPlacements);
 
     let retUserPlacements = [];
 

--- a/src/components/GameEditProcess.jsx
+++ b/src/components/GameEditProcess.jsx
@@ -61,6 +61,7 @@ export const GameEditProcess = ({
 
     // ユーザーオブジェクトのプロパティを取得
     const userPlacements = getUserPlacements(engine.world.bodies);
+    console.log(userPlacements);
 
     let retUserPlacements = [];
 
@@ -215,7 +216,7 @@ export const GameEditProcess = ({
   const returnUserProperty = (object) => {
     const position = changePosition(object.position);
     position.x = UserPlacementCenterX
-    const label = object.label;
+    const label = object.label.match(/user(.*)/g) ? object.label : "userStatic";
     const isStatic = object.label === "userMove" ? false : object.isStatic;
     const objectId = object.id;
     const bodiesType = object.bodiesType;


### PR DESCRIPTION
# 概要
テストプレイ時に、ユーザーが配置できるオブジェクトに設定がなくても移動できるようにしました。

## 挙動
[動画](https://i.gyazo.com/687aed4b50b606f75a77fc5539c32987.mp4)

## 原因
ユーザー配置オブジェクトの物理可否を追加したことにより、ラベルの挙動が変わってしまったため修正しました。
未設定の場合は「ユーザーが配置できる静止オブジェクト」として扱います。